### PR TITLE
Celo config cleanup

### DIFF
--- a/ops/internal/config/chain.go
+++ b/ops/internal/config/chain.go
@@ -120,8 +120,7 @@ type Hardforks struct {
 	InteropTime            *HardforkTime `toml:"interop_time"`
 	JovianTime             *HardforkTime `toml:"jovian_time"`
 	// Celo-specific forks
-	Cel2Time         *HardforkTime `toml:"cel2_time,omitempty"`
-	GingerbreadBlock *uint64       `toml:"gingerbread_block,omitempty"`
+	Cel2Time *HardforkTime `toml:"cel2_time,omitempty"`
 }
 
 type Genesis struct {

--- a/superchain/configs/mainnet/celo.toml
+++ b/superchain/configs/mainnet/celo.toml
@@ -31,6 +31,12 @@ gas_paying_token = "0x057898f3C43F129a17517B9056D23851F124b19f"
 [celo]
   eip1559_base_fee_floor = 25000000000
 
+[alt_da]
+  da_challenge_contract_address = "0x0000000000000000000000000000000000000000"
+  da_challenge_window = 1
+  da_resolve_window = 1
+  da_commitment_type = "GenericCommitment"
+
 [genesis]
   l2_time = 1742957258
   [genesis.l1]

--- a/superchain/configs/mainnet/celo.toml
+++ b/superchain/configs/mainnet/celo.toml
@@ -22,7 +22,6 @@ gas_paying_token = "0x057898f3C43F129a17517B9056D23851F124b19f"
   pectra_blob_schedule_time = 1752073200 # Wed 9 Jul 2025 15:00:00 UTC
   isthmus_time = 1752073200 # Wed 9 Jul 2025 15:00:00 UTC
   cel2_time = 1742957258 # Wed 26 Mar 2025 02:47:38 UTC
-  gingerbread_block = 21616000
 
 [optimism]
   eip1559_elasticity = 5

--- a/superchain/configs/sepolia/celo-sep.toml
+++ b/superchain/configs/sepolia/celo-sep.toml
@@ -21,7 +21,6 @@ gas_paying_token = "0x3C7011fD5e6Aed460cAa4985cF8d8Caba435b092"
   holocene_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   isthmus_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
   cel2_time = 0 # Thu 1 Jan 1970 00:00:00 UTC
-  gingerbread_block = 0
 
 [optimism]
   eip1559_elasticity = 5


### PR DESCRIPTION
This PR, adds missing alt_da config for celo mainnet and removes the gingerbread block from the superchain registry.

It was probably a mistake to add the gingerbread block to the superchain registry since the super chain registry is designed to hold post-Bedrock hardforks, and the gingerbread block is a pre-bedrock hard fork, so now it will be managed as a hard-coded override in op-geth which makes it consistent with all the other pre-bedrock hardforks. See the PR - https://github.com/celo-org/op-geth/pull/481

Relates to - https://github.com/celo-org/celo-blockchain-planning/issues/1346